### PR TITLE
Resolve aws sdk versions

### DIFF
--- a/c3-cloudfront-clear-cache.php
+++ b/c3-cloudfront-clear-cache.php
@@ -17,9 +17,19 @@ define( 'C3_PLUGIN_ROOT', __FILE__ );
 $c3 = C3_Controller::get_instance();
 $c3->init();
 
+function c3_get_aws_sdk_version() {
+	if ( class_exists('Aws') ) {
+	    return c3_get_loaded_aws_sdk_version();
+    }
+    if ( c3_is_later_than_php_55() ) {
+	    return 'v3';
+    }
+    return 'v2';
+}
+
 function c3_is_later_than_php_55() {
 	$is_later_than_55 = true;
-	if ( version_compare(phpversion(), '5.5', '<') ) {
+	if ( version_compare( phpversion(), '5.5', '<') ) {
 		$is_later_than_55 = false;
 	}
 	return apply_filters( 'c3_select_aws_sdk', $is_later_than_55 );
@@ -46,7 +56,7 @@ class C3_Controller {
 	 * @since 4.0.0
 	 */
 	public function init() {
-		add_action( 'plugins_loaded',array( $this, 'plugins_loaded' ) );
+		add_action( 'plugins_loaded', array( $this, 'plugins_loaded' ) );
 	}
 
 	/**
@@ -58,13 +68,11 @@ class C3_Controller {
 	 * @since 5.3.4
 	 */
 	public function plugins_loaded() {
-		if ( ! class_exists('Aws') ) {
-			if ( c3_is_later_than_php_55() ) {
-				require_once( dirname( __FILE__ ).'/libs/aws.v3.phar' );
-			} else {
-				require_once( dirname( __FILE__ ).'/libs/aws.v2.phar' );
-			}
-		}
+	    if ( 'v2' === c3_get_aws_sdk_version() ) {
+		    require_once( dirname( __FILE__ ).'/libs/aws.v2.phar' );
+        } else {
+		    require_once( dirname( __FILE__ ).'/libs/aws.v3.phar' );
+        }
 		require_once( dirname( __FILE__ ).'/module/includes.php' );
 
 		$this->base = new C3_Base();

--- a/c3-cloudfront-clear-cache.php
+++ b/c3-cloudfront-clear-cache.php
@@ -10,23 +10,16 @@
  * @package c3-cloudfront-clear-cache
  */
 
-if ( c3_is_later_than_php_55() ) {
-	require_once( dirname( __FILE__ ).'/libs/aws.v3.phar' );
-} else {
-	require_once( dirname( __FILE__ ).'/libs/aws.v2.phar' );
-}
 define( 'C3_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'C3_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'C3_PLUGIN_ROOT', __FILE__ );
-
-require_once( dirname( __FILE__ ).'/module/includes.php' );
 
 $c3 = C3_Controller::get_instance();
 $c3->init();
 
 function c3_is_later_than_php_55() {
-    $is_later_than_55 = true;
-	if ( 5.5 > (float) phpversion() ) {
+	$is_later_than_55 = true;
+	if ( version_compare(phpversion(), '5.5', '<') ) {
 		$is_later_than_55 = false;
 	}
 	return apply_filters( 'c3_select_aws_sdk', $is_later_than_55 );
@@ -53,6 +46,27 @@ class C3_Controller {
 	 * @since 4.0.0
 	 */
 	public function init() {
+		add_action( 'plugins_loaded',array( $this, 'plugins_loaded' ) );
+	}
+
+	/**
+	 *  Initialize Plugin
+	 *
+	 * @access public
+	 * @param none
+	 * @return none
+	 * @since 5.3.4
+	 */
+	public function plugins_loaded() {
+		if ( ! class_exists('Aws') ) {
+			if ( c3_is_later_than_php_55() ) {
+				require_once( dirname( __FILE__ ).'/libs/aws.v3.phar' );
+			} else {
+				require_once( dirname( __FILE__ ).'/libs/aws.v2.phar' );
+			}
+		}
+		require_once( dirname( __FILE__ ).'/module/includes.php' );
+
 		$this->base = new C3_Base();
 		$menu = C3_Menus::get_instance();
 		$menu->init();

--- a/module/includes.php
+++ b/module/includes.php
@@ -2,17 +2,17 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
-
+require_once( 'utils.php' );
 require_once( 'base.php' );
 require_once( 'model/client-base.php' );
 
 // Model
 require_once( 'model/auth.php' );
 require_once( 'model/invalidation.php' );
-if ( c3_is_later_than_php_55() ) {
-	require_once( 'model/client-v3.php' );
-} else {
+if ( 'v2' === c3_get_aws_sdk_version() ) {
 	require_once( 'model/client-v2.php' );
+} else {
+	require_once( 'model/client-v3.php' );
 }
 if ( ! class_exists( 'CF_preview_fix' ) ) {
 	require_once( 'model/cf-preview-fix.php' );

--- a/module/model/auth.php
+++ b/module/model/auth.php
@@ -51,7 +51,7 @@ class C3_Auth extends C3_Base {
 		if ( ! isset( $options['distribution_id'] ) || ! $options['distribution_id'] ) {
 			return new WP_Error( 'C3 Notice', "CloudFront Distribution ID is not defined." );
 		}
-		if ( c3_is_later_than_php_55() ) {
+		if ( 'v2' !== c3_get_aws_sdk_version() ) {
 			$sdk = C3_Client_V3::get_instance();
 		} else {
 			//@TODO: for php ~5.4, do not Authenication now.

--- a/module/model/class.logs.php
+++ b/module/model/class.logs.php
@@ -32,7 +32,7 @@ class C3_Logs extends C3_Base {
 			return $lists;
 		}
 
-		if ( c3_is_later_than_php_55() ) {
+		if ( 'v2' !== c3_get_aws_sdk_version() ) {
 			$sdk = C3_Client_V3::get_instance();
 		} else {
 			$sdk = C3_Client_V2::get_instance();

--- a/module/model/client-v3.php
+++ b/module/model/client-v3.php
@@ -56,7 +56,7 @@ class C3_Client_V3 extends C3_Client_Base {
 			return $credential;
 		}
 		$param = array(
-			'version' => '2017-10-30',
+			'version' => 'latest',
 			'region'  => 'us-east-1',
 		);
 		if ( $credential ) {

--- a/module/model/client-v3.php
+++ b/module/model/client-v3.php
@@ -62,7 +62,7 @@ class C3_Client_V3 extends C3_Client_Base {
 		if ( $credential ) {
 			$param = array_merge( $param, $credential );
 		}
-		$cf_client = new CloudFrontClient( $param );
+		$cf_client = CloudFrontClient::factory( $param );
 		return $cf_client;
 	}
 

--- a/module/model/invalidation.php
+++ b/module/model/invalidation.php
@@ -140,7 +140,7 @@ class C3_Invalidation extends C3_Base {
 	public function invalidation( $post = false ) {
 
 		$key = self::C3_INVALIDATION_KEY;
-		if ( c3_is_later_than_php_55() ) {
+		if ( 'v2' !== c3_get_aws_sdk_version() ) {
 			$sdk = C3_Client_V3::get_instance();
 		} else {
 			$sdk = C3_Client_V2::get_instance();
@@ -173,7 +173,7 @@ class C3_Invalidation extends C3_Base {
 	 **/
 	private function _create_cf_client() {
 		$options = $this->get_c3_options();
-		if ( c3_is_later_than_php_55() ) {
+		if ( 'v2' !== c3_get_aws_sdk_version() ) {
 			$sdk = C3_Client_V3::get_instance();
 		} else {
 			$sdk = C3_Client_V2::get_instance();

--- a/module/utils.php
+++ b/module/utils.php
@@ -1,0 +1,13 @@
+<?php
+
+function c3_get_loaded_aws_sdk_version() {
+	$const = get_defined_constants('user');
+	return c3_check_aws_sdk_version($const);
+}
+
+function c3_check_aws_sdk_version($constants) {
+	if (preg_grep('/AWS-3/', array_keys($constants['user']))) {
+		return 'v3';
+	}
+	return 'v2';
+}

--- a/tests/test-c3-cloudfront-clear-cache.php
+++ b/tests/test-c3-cloudfront-clear-cache.php
@@ -2,12 +2,6 @@
 require_once( 'c3-cloudfront-clear-cache.php' );
 class CloudFront_Clear_Cache_Test extends WP_UnitTestCase
 {
-	protected $C3;
-	function setUp() {
-		$this->C3 = C3_Controller::get_instance();
-		$this->C3->init();
-	}
-
 	function test_should_defined_c3_plugin_path() {
 		$result = defined('C3_PLUGIN_PATH');
 		$this->assertTrue( $result );

--- a/tests/test-c3-utils.php
+++ b/tests/test-c3-utils.php
@@ -1,0 +1,29 @@
+<?php
+require_once( 'module/utils.php' );
+class C3_Utils_Test extends WP_UnitTestCase {
+	/**
+	 * @test
+	 */
+	function test_should_return_v3_when_defined_AWS_v3_const() {
+		$constants = array(
+			'user' => array(
+				'AWS-3.x.x.PHAR_PHAR' => true
+			)
+		);
+		$version = c3_check_aws_sdk_version($constants);
+		$this->assertSame( 'v3', $version );
+	}
+
+	/**
+	 * @test
+	 */
+	function test_should_return_v2_when_defined_AWS_v2_const() {
+		$constants = array(
+			'user' => array(
+				'AWS-2.x.x.PHAR_PHAR' => true
+			)
+		);
+		$version = c3_check_aws_sdk_version($constants);
+		$this->assertSame( 'v2', $version );
+	}
+}


### PR DESCRIPTION
外部プラグインがaws-sdk(Phar)でv2のものをよんでいた場合に、処理系統をそっちに流すようにアップデート。
`AWS-2.x.x.PHAR_PHAR`の定数を使う