### PR TITLE
modified cookey path

### DIFF
--- a/c3-cloudfront-clear-cache.php
+++ b/c3-cloudfront-clear-cache.php
@@ -15,8 +15,8 @@ define( 'C3_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'C3_PLUGIN_ROOT', __FILE__ );
 
 // fixtures
-require_once( 'module/model/fixtures/wp_is_mobile.php' );
-require_once( 'module/model/fixtures/avoid_preview_cache.php' );
+require_once( __DIR__ . '/module/model/fixtures/wp_is_mobile.php' );
+require_once( __DIR__ . '/module/model/fixtures/avoid_preview_cache.php' );
 
 $c3 = C3_Controller::get_instance();
 $c3->init();

--- a/module/model/fixtures/avoid_preview_cache.php
+++ b/module/model/fixtures/avoid_preview_cache.php
@@ -3,6 +3,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
+if ( ! defined( 'C3_AVOID_CACHE_COOKEY_KEY' ) ) {
+	define( 'C3_AVOID_CACHE_COOKEY_KEY', 'wordpress_loginuser_last_visit' );
+}
+
 /**
  * Set cookie to avoid CloudFront cache if user sign in
  *
@@ -11,7 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 add_action( 'plugins_loaded', function() {
 	if ( is_user_logged_in() ) {
-		setcookie( 'wordpress_loginuser_last_visit', time() );
+		$cookie_path = preg_replace( '#^https?://[^/]+/?#','/',home_url( '/' ) );
+		setcookie( C3_AVOID_CACHE_COOKEY_KEY, time(), 0, $cookie_path );
 	}
 } );
 
@@ -36,5 +41,6 @@ register_deactivation_hook( C3_PLUGIN_ROOT, 'c3_unset_avoid_cache_cookie' );
  * @since 5.1.0
  */
 function c3_unset_avoid_cache_cookie() {
-	setcookie('wordpress_loginuser_last_visit', '', time() - 1800);
+	$cookie_path = preg_replace( '#^https?://[^/]+/?#','/',home_url( '/' ) );
+	setcookie( C3_AVOID_CACHE_COOKEY_KEY, '', time() - 1800, $cookie_path );
 }


### PR DESCRIPTION
setcookie() で path を指定していないため、以下の現象が発生しているので、それに対する修正です。

- /wp-admin/ で setcookie() する。
- path (第4引数) が指定されてないのでカレントディレクトリ /wp-admin/ が path として採用される
- 記事を見ると path が /wp-admin/ ではないので wordpress_loginuser_last_visit cookie は利用されない。