### PR TITLE
Replace the top level menu with a Settings submenu

### DIFF
--- a/module/view/menus.php
+++ b/module/view/menus.php
@@ -59,7 +59,7 @@ class C3_Menus extends C3_Base {
 	 */
 	public function define_menus() {
 		$root = C3_Admin::get_instance();
-		add_menu_page(
+		add_options_page(
 			__( 'CloudFront Settings', self::$text_domain ),
 			__( 'CloudFront Settings', self::$text_domain ),
 			'administrator',


### PR DESCRIPTION
Fixes #42.

Saving options still works as expected.