### PR TITLE
Prefixing env variables to prevent conflicts with other plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ $ cd c3-cloudfront-clear-cache
 
 The plugin can be configured by defining the following environment variables:
 
-- `AWS_ACCESS_KEY_ID`
-- `AWS_SECRET_ACCESS_KEY`
+- `C3_AWS_ACCESS_KEY_ID`
+- `C3_AWS_SECRET_ACCESS_KEY`
 - `C3_DISTRIBUTION_ID`
 
 ## Filters

--- a/module/base.php
+++ b/module/base.php
@@ -163,8 +163,8 @@ class C3_Base {
 	 * @access public
 	 */
 	public static function get_access_key() {
-		if(defined('AWS_ACCESS_KEY_ID')) {
-			return AWS_ACCESS_KEY_ID;
+		if(defined('C3_AWS_ACCESS_KEY_ID')) {
+			return C3_AWS_ACCESS_KEY_ID;
 		} else {
 			$option = self::get_c3_option('access_key');
 			return $option;
@@ -178,8 +178,8 @@ class C3_Base {
 	 * @access public
 	 */
 	public static function get_secret_key() {
-		if(defined('AWS_SECRET_ACCESS_KEY')) {
-			return AWS_SECRET_ACCESS_KEY;
+		if(defined('C3_AWS_SECRET_ACCESS_KEY')) {
+			return C3_AWS_SECRET_ACCESS_KEY;
 		} else {
 			$option = self::get_c3_option('secret_key');
 			return $option;

--- a/readme.txt
+++ b/readme.txt
@@ -66,15 +66,15 @@ This plugin send following page url to CloudFront Invalidation API.
 
 The plugin can be configured by defining the following variables:
 
-- `AWS_ACCESS_KEY_ID`
-- `AWS_SECRET_ACCESS_KEY`
+- `C3_AWS_ACCESS_KEY_ID`
+- `C3_AWS_SECRET_ACCESS_KEY`
 - `C3_DISTRIBUTION_ID`
 
 You can put these variables like the code into the wp-config.php
 
 `php
-define( 'AWS_ACCESS_KEY_ID', '' );
-define( 'AWS_SECRET_ACCESS_KEY', '' );
+define( 'C3_AWS_ACCESS_KEY_ID', '' );
+define( 'C3_AWS_SECRET_ACCESS_KEY', '' );
 define( 'C3_DISTRIBUTION_ID', '' );
 `
 


### PR DESCRIPTION
The env variable names can cause conflicts since AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID are common setting names used by AWS. Prefixing with "C3_" prevents conflicts.