### PR TITLE
required version of PHP upgrade 5.5 to 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "type": "wordpress-plugin",
   "require": {
-    "php": ">=5.5"
+    "php": ">=7.0"
   },
   "require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "*",


### PR DESCRIPTION
required version of PHP upgraded from 5.5 to 7.0 because it contains code that does not work on PHP 5.5.
ex. Variable-length argument lists, parameter declared as scalar type