### PR TITLE
Added more hooks for cache invalidation path adjustments

### DIFF
--- a/classes/AWS/Invalidation_Batch_Service.php
+++ b/classes/AWS/Invalidation_Batch_Service.php
@@ -103,7 +103,8 @@ class Invalidation_Batch_Service {
 	 */
 	public function create_batch_by_post( string $home_url, string $distribution_id, \WP_Post $post = null ) {
 		$invalidation_batch = new Invalidation_Batch();
-		$invalidation_batch->put_invalidation_path( $home_url );
+		$invalidation_path  = $this->hook_service->apply_filters( 'c3_invalidation_post_batch_home_path', $home_url );
+		$invalidation_batch->put_invalidation_path( $invalidation_path );
 		$invalidation_batch = $this->put_post_invalidation_batch( $invalidation_batch, $post );
 		return $invalidation_batch->get_invalidation_request_parameter( $distribution_id );
 	}
@@ -117,7 +118,8 @@ class Invalidation_Batch_Service {
 	 */
 	public function create_batch_by_posts( string $home_url, string $distribution_id, array $posts = array() ) {
 		$invalidation_batch = new Invalidation_Batch();
-		$invalidation_batch->put_invalidation_path( $home_url );
+		$invalidation_path  = $this->hook_service->apply_filters( 'c3_invalidation_posts_batch_home_path', $home_url );
+		$invalidation_batch->put_invalidation_path( $invalidation_path );
 		foreach ( $posts as $post ) {
 			$invalidation_batch = $this->put_post_invalidation_batch( $invalidation_batch, $post );
 		}
@@ -132,7 +134,8 @@ class Invalidation_Batch_Service {
 	 */
 	public function create_batch_for_all( string $distribution_id ) {
 		$invalidation_batch = new Invalidation_Batch();
-		$invalidation_batch->put_invalidation_path( '/*' );
+		$invalidation_path  = $this->hook_service->apply_filters( 'c3_invalidation_manual_batch_all_path', '/*' );
+		$invalidation_batch->put_invalidation_path( $invalidation_path );
 		return $invalidation_batch->get_invalidation_request_parameter( $distribution_id );
 	}
 }


### PR DESCRIPTION
We have a special WordPress setup in a subdirectory and have the need to adjust the invalidation paths to our needs before invalidating the whole domain.

In the old version, this was possible without any problem. So I readded some hooks to adjust the invalidation paths for manual invalidations of posts or the invalidation of the complete site (all).

We are using right now the forked version but it would be great to find this in an upcoming release.

Thanks for your great work! 