### PR TITLE
Fix invalidation path for post type without archive page

### DIFF
--- a/classes/WP/Post.php
+++ b/classes/WP/Post.php
@@ -53,6 +53,9 @@ class Post {
 	 * @param string $url Target URL.
 	 */
 	public function parse_url( string $url ) {
+		if ( ! isset($url) || empty($url)) {
+			return new \WP_Error( 'URL must not be empty' );
+		}
 		$parsed_url = parse_url( $url );
 		$url        = $parsed_url['scheme'] . '://' . $parsed_url['host'];
 		if ( isset( $parsed_url['path'] ) ) {

--- a/tests/WP/Post_Test.php
+++ b/tests/WP/Post_Test.php
@@ -57,4 +57,13 @@ class Post_Test extends \WP_UnitTestCase {
             [ 'http://example.com/hello-world', 'http://example.com/hello-world' ],
         ];
     }
+
+    /**
+     * parse_url should return an instance of WP_Error when url is empty
+     */
+    public function test_parse_url_empty() {
+        $post = new WP\Post();
+        $result = $post->parse_url( '' );
+        $this->assertInstanceOf( 'WP_Error', $result );
+    }
 }


### PR DESCRIPTION
When an invalidation is submitted for post type that does not have an archive page, the invalidation paths submitted may include the path "://*". This results in a 400 bad request status from the CloudFront API. The issue can be traced to the parse_url function in classes/WP/Post.php. The function will accept a null or empty string for the URL. Doing so will cause the function to return the string "://". Possibly related to #107.

Since the calling function get_the_post_type_archive_links() is already written to handle a situation where parse_url returns an instance of WP_Error, I have updated parse_url to return a WP_Error object when the given url is empty or null. That appears to be the intended behavior from the existing code. As a result of this change, cache invalidations for post types without an archive page do not include the invalid path in the submission to CloudFront.

A unit test has been added to test/WP/Post_Test.php to validate that parse_url returns an instance of the WP_Error class when given an empty string.