### PR TITLE
Update Post_Service to query any post type

### DIFF
--- a/classes/WP/Post_Service.php
+++ b/classes/WP/Post_Service.php
@@ -28,6 +28,7 @@ class Post_Service {
 		$query = new \WP_Query(
 			array(
 				'post__in' => $post_ids,
+				'post_type' => 'any'
 			)
 		);
 		$posts = $query->get_posts();


### PR DESCRIPTION
Currently, the cache purge by IDs feature only works with the default post type.
This PR extends the functionality to support any registered post type, ensuring cache invalidation works consistently across custom post types as well.

Why:
It’s quite common for projects to have pages that depend on listings of posts or other custom post types. However, the plugin doesn’t automatically detect these relationships, which can result in related pages remaining cached after updates.

Before this change, attempting to purge the cache of a page with ID 4583 would only clear the `/` path:

<img width="732" height="787" alt="image" src="https://github.com/user-attachments/assets/e870027e-21e7-4ecb-a0b7-72f18753e8e8" />

With this update, the actual page path is now included in the purge, ensuring the correct content is invalidated:

<img width="780" height="812" alt="image" src="https://github.com/user-attachments/assets/0649c7db-b979-48ef-8e54-91951bdc35cf" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ID-based post listing to include all content types, ensuring custom and non-standard posts are returned when specified.
  * Resolves missing items when referencing IDs from various content types and aligns results with the requested list.
  * Improves reliability and consistency of content retrieval across the app, reducing confusion and the need for manual workarounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->