### PR TITLE
Fix CloudFront invalidation summary array handling

### DIFF
--- a/classes/AWS/CloudFront_Service.php
+++ b/classes/AWS/CloudFront_Service.php
@@ -315,7 +315,16 @@ class CloudFront_Service {
 
 			if ( isset( $result['Quantity'] ) && $result['Quantity'] > 0 && isset( $result['Items']['InvalidationSummary'] ) ) {
 				error_log( 'C3 CloudFront: Found ' . $result['Quantity'] . ' invalidations' );
-				return $result['Items']['InvalidationSummary'];
+				
+				// InvalidationSummaryが単一のオブジェクトの場合は配列に変換
+				$invalidations = $result['Items']['InvalidationSummary'];
+				if ( ! is_array( $invalidations ) || ( isset( $invalidations[0] ) === false && isset( $invalidations['Id'] ) ) ) {
+					// 単一のオブジェクトの場合は配列にラップ
+					$invalidations = array( $invalidations );
+				}
+				
+				error_log( 'C3 CloudFront: Processed invalidations data: ' . print_r( $invalidations, true ) );
+				return $invalidations;
 			}
 
 			error_log( 'C3 CloudFront: No invalidations found' );

--- a/tests/AWS/CloudFront_Service_Test.php
+++ b/tests/AWS/CloudFront_Service_Test.php
@@ -177,4 +177,173 @@ class CloudFront_Service_Test extends TestCase {
 		$this->assertEquals( 'C3 Get Invalidation Error', $result->get_error_code() );
 		$this->assertStringContainsString( 'Failed to create CloudFront client', $result->get_error_message() );
 	}
+
+	/**
+	 * Test list_invalidations with single invalidation response (string case)
+	 * This test reproduces the original error scenario
+	 */
+	public function test_list_invalidations_single_string_response() {
+		$mock_env = WP_Mock_Helper::create_mock_environment();
+		$mock_options = WP_Mock_Helper::create_mock_options_service( [
+			'distribution_id' => 'E123456789',
+			'access_key' => 'test-key',
+			'secret_key' => 'test-secret'
+		] );
+		$mock_hooks = WP_Mock_Helper::create_mock_hooks_service();
+
+		// Mock the CloudFront_HTTP_Client to return a string response
+		$mock_client = \Mockery::mock( 'C3_CloudFront_Cache_Controller\AWS\CloudFront_HTTP_Client' );
+		$mock_client->shouldReceive( 'list_invalidations' )
+			->andReturn( 'I123456789' ); // This is what causes the error
+
+		// Create a partial mock of CloudFront_Service to inject our mock client
+		$service = \Mockery::mock( CloudFront_Service::class, [ $mock_env, $mock_options, $mock_hooks ] )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
+
+		$service->shouldReceive( 'create_client' )
+			->andReturn( $mock_client );
+
+		$service->shouldReceive( 'get_distribution_id' )
+			->andReturn( 'E123456789' );
+
+		$result = $service->list_invalidations();
+		
+		// The method should handle the string response gracefully
+		$this->assertIsArray( $result );
+		$this->assertEmpty( $result ); // Should return empty array for invalid data
+	}
+
+	/**
+	 * Test list_invalidations with single invalidation response (object case)
+	 */
+	public function test_list_invalidations_single_object_response() {
+		$mock_env = WP_Mock_Helper::create_mock_environment();
+		$mock_options = WP_Mock_Helper::create_mock_options_service( [
+			'distribution_id' => 'E123456789',
+			'access_key' => 'test-key',
+			'secret_key' => 'test-secret'
+		] );
+		$mock_hooks = WP_Mock_Helper::create_mock_hooks_service();
+
+		// Mock the CloudFront_HTTP_Client to return a single object response
+		$mock_client = \Mockery::mock( 'C3_CloudFront_Cache_Controller\AWS\CloudFront_HTTP_Client' );
+		$mock_client->shouldReceive( 'list_invalidations' )
+			->andReturn( [
+				'Quantity' => 1,
+				'Items' => [
+					'InvalidationSummary' => [
+						'Id' => 'I123456789',
+						'Status' => 'Completed',
+						'CreateTime' => '2024-01-15T10:30:00Z'
+					]
+				]
+			] );
+
+		$service = \Mockery::mock( CloudFront_Service::class, [ $mock_env, $mock_options, $mock_hooks ] )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
+
+		$service->shouldReceive( 'create_client' )
+			->andReturn( $mock_client );
+
+		$service->shouldReceive( 'get_distribution_id' )
+			->andReturn( 'E123456789' );
+
+		$result = $service->list_invalidations();
+		
+		// Should return array with single invalidation
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$this->assertEquals( 'I123456789', $result[0]['Id'] );
+		$this->assertEquals( 'Completed', $result[0]['Status'] );
+	}
+
+	/**
+	 * Test list_invalidations with multiple invalidations response
+	 */
+	public function test_list_invalidations_multiple_response() {
+		$mock_env = WP_Mock_Helper::create_mock_environment();
+		$mock_options = WP_Mock_Helper::create_mock_options_service( [
+			'distribution_id' => 'E123456789',
+			'access_key' => 'test-key',
+			'secret_key' => 'test-secret'
+		] );
+		$mock_hooks = WP_Mock_Helper::create_mock_hooks_service();
+
+		// Mock the CloudFront_HTTP_Client to return multiple invalidations
+		$mock_client = \Mockery::mock( 'C3_CloudFront_Cache_Controller\AWS\CloudFront_HTTP_Client' );
+		$mock_client->shouldReceive( 'list_invalidations' )
+			->andReturn( [
+				'Quantity' => 2,
+				'Items' => [
+					'InvalidationSummary' => [
+						[
+							'Id' => 'I123456789',
+							'Status' => 'Completed',
+							'CreateTime' => '2024-01-15T10:30:00Z'
+						],
+						[
+							'Id' => 'I987654321',
+							'Status' => 'InProgress',
+							'CreateTime' => '2024-01-15T11:00:00Z'
+						]
+					]
+				]
+			] );
+
+		$service = \Mockery::mock( CloudFront_Service::class, [ $mock_env, $mock_options, $mock_hooks ] )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
+
+		$service->shouldReceive( 'create_client' )
+			->andReturn( $mock_client );
+
+		$service->shouldReceive( 'get_distribution_id' )
+			->andReturn( 'E123456789' );
+
+		$result = $service->list_invalidations();
+		
+		// Should return array with multiple invalidations
+		$this->assertIsArray( $result );
+		$this->assertCount( 2, $result );
+		$this->assertEquals( 'I123456789', $result[0]['Id'] );
+		$this->assertEquals( 'I987654321', $result[1]['Id'] );
+	}
+
+	/**
+	 * Test list_invalidations with no invalidations
+	 */
+	public function test_list_invalidations_no_invalidations() {
+		$mock_env = WP_Mock_Helper::create_mock_environment();
+		$mock_options = WP_Mock_Helper::create_mock_options_service( [
+			'distribution_id' => 'E123456789',
+			'access_key' => 'test-key',
+			'secret_key' => 'test-secret'
+		] );
+		$mock_hooks = WP_Mock_Helper::create_mock_hooks_service();
+
+		// Mock the CloudFront_HTTP_Client to return no invalidations
+		$mock_client = \Mockery::mock( 'C3_CloudFront_Cache_Controller\AWS\CloudFront_HTTP_Client' );
+		$mock_client->shouldReceive( 'list_invalidations' )
+			->andReturn( [
+				'Quantity' => 0
+			] );
+
+		$service = \Mockery::mock( CloudFront_Service::class, [ $mock_env, $mock_options, $mock_hooks ] )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
+
+		$service->shouldReceive( 'create_client' )
+			->andReturn( $mock_client );
+
+		$service->shouldReceive( 'get_distribution_id' )
+			->andReturn( 'E123456789' );
+
+		$result = $service->list_invalidations();
+		
+		// Should return empty array
+		$this->assertIsArray( $result );
+		$this->assertEmpty( $result );
+	}
 }      


### PR DESCRIPTION
- Fix issue where single InvalidationSummary object was not properly converted to array
- Add comprehensive test cases for various response formats:
  - Single object response
  - Multiple objects response
  - String response (error case)
  - No invalidations response
- Add debug logging for better troubleshooting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Ensures CloudFront invalidations are consistently returned and displayed, even when only a single invalidation exists.
  - Improves robustness against unexpected response shapes, preventing empty or incorrect listings.
  - Adds logging for better visibility into processed invalidation data.

- Tests
  - Introduces comprehensive unit tests covering single, multiple, and no invalidation scenarios, plus malformed responses.
  - Maintains existing authentication error coverage.

- Chores
  - Enhances reliability and stability of cache invalidation status reporting without changing user-facing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->