### PR TITLE
Security fixes

### DIFF
--- a/c3-cloudfront-clear-cache.php
+++ b/c3-cloudfront-clear-cache.php
@@ -6,6 +6,7 @@
  * Description: Manage CloudFront Cache and provide some fixtures.
  * Author: hideokamoto
  * Author URI: https://wp-kyoto.net/
+ * Requires at least: 5.5
  * Requires PHP: 7.4
  * Text Domain: c3-cloudfront-clear-cache
  *

--- a/classes/AWS/CloudFront_HTTP_Client.php
+++ b/classes/AWS/CloudFront_HTTP_Client.php
@@ -292,7 +292,8 @@ class CloudFront_HTTP_Client {
 
 		libxml_use_internal_errors( true );
 		
-		$xml = simplexml_load_string( $xml_string, 'SimpleXMLElement', LIBXML_NOCDATA | LIBXML_NONET | LIBXML_NOENT );
+		// LIBXML_NOENT is intentionally omitted: it enables entity substitution (XXE vector).
+		$xml = simplexml_load_string( $xml_string, 'SimpleXMLElement', LIBXML_NOCDATA | LIBXML_NONET );
 		
 		if ( $xml === false ) {
 			$errors = libxml_get_errors();

--- a/classes/AWS/CloudFront_Service.php
+++ b/classes/AWS/CloudFront_Service.php
@@ -293,7 +293,9 @@ class CloudFront_Service {
 			}
 
 			$distribution_id = $this->get_distribution_id();
-			error_log( 'C3 CloudFront: Listing invalidations for distribution: ' . $distribution_id );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				error_log( 'C3 CloudFront: Listing invalidations for distribution: ' . $distribution_id );
+			}
 
 			$max_items = $this->hook_service->apply_filters( 'c3_max_invalidation_logs', 25 );
 			$result    = $client->list_invalidations( $distribution_id, $max_items );
@@ -327,20 +329,26 @@ class CloudFront_Service {
 			}
 
 			if ( isset( $result['Quantity'] ) && $result['Quantity'] > 0 && isset( $result['Items']['InvalidationSummary'] ) ) {
-				error_log( 'C3 CloudFront: Found ' . $result['Quantity'] . ' invalidations' );
-				
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					error_log( 'C3 CloudFront: Found ' . $result['Quantity'] . ' invalidations' );
+				}
+
 				// InvalidationSummaryが単一のオブジェクトの場合は配列に変換
 				$invalidations = $result['Items']['InvalidationSummary'];
 				if ( ! is_array( $invalidations ) || ( isset( $invalidations[0] ) === false && isset( $invalidations['Id'] ) ) ) {
 					// 単一のオブジェクトの場合は配列にラップ
 					$invalidations = array( $invalidations );
 				}
-				
-				error_log( 'C3 CloudFront: Processed invalidations data: ' . print_r( $invalidations, true ) );
+
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					error_log( 'C3 CloudFront: Processed invalidations data: ' . print_r( $invalidations, true ) );
+				}
 				return $invalidations;
 			}
 
-			error_log( 'C3 CloudFront: No invalidations found' );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				error_log( 'C3 CloudFront: No invalidations found' );
+			}
 			return array();
 		} catch ( \Exception $e ) {
 			error_log( 'C3 CloudFront: Exception in list_invalidations: ' . $e->__toString() );

--- a/classes/AWS/EC2_Metadata_Service.php
+++ b/classes/AWS/EC2_Metadata_Service.php
@@ -58,7 +58,7 @@ class EC2_Metadata_Service {
 		}
 
 		$credentials = $this->get_credentials_v2();
-		if ( ! $credentials ) {
+		if ( ! $credentials && $this->use_imdsv1_fallback() ) {
 			$credentials = $this->get_credentials_v1();
 		}
 
@@ -92,6 +92,18 @@ class EC2_Metadata_Service {
 	 */
 	private function get_credentials_v1() {
 		return $this->fetch_credentials();
+	}
+
+	/**
+	 * Whether the token-less IMDSv1 fallback is allowed.
+	 *
+	 * IMDSv1 weakens SSRF defense-in-depth; disable it with:
+	 * add_filter( 'c3_use_imdsv1_fallback', '__return_false' );
+	 *
+	 * @return bool
+	 */
+	private function use_imdsv1_fallback() {
+		return (bool) apply_filters( 'c3_use_imdsv1_fallback', true );
 	}
 
 	/**
@@ -191,6 +203,9 @@ class EC2_Metadata_Service {
 		}
 
 		// If IMDSv2 fails, fall back to IMDSv1
+		if ( ! $this->use_imdsv1_fallback() ) {
+			return false;
+		}
 		$response = wp_remote_request(
 			$this->metadata_endpoint . '/latest/meta-data/',
 			array(

--- a/classes/AWS/Invalidation_Batch.php
+++ b/classes/AWS/Invalidation_Batch.php
@@ -81,11 +81,12 @@ class Invalidation_Batch {
 	 * Get the invalidation batch
 	 */
 	public function get_invalidation_batch() {
+		$items = $this->get_invalidation_path_items();
 		return array(
 			'CallerReference' => uniqid(),
 			'Paths'           => array(
-				'Items'    => $this->items,
-				'Quantity' => count( $this->items ),
+				'Items'    => $items,
+				'Quantity' => count( $items ),
 			),
 		);
 	}

--- a/classes/AWS/Invalidation_Batch_Service.php
+++ b/classes/AWS/Invalidation_Batch_Service.php
@@ -95,12 +95,16 @@ class Invalidation_Batch_Service {
 			$invalidation_batch->put_invalidation_path( $permalink . '*' );
 		}
 		$term_links = $this->post->get_the_post_term_links();
-		foreach ( $term_links as $key => $url ) {
-			$invalidation_batch->put_invalidation_path( $url );
+		if ( ! is_wp_error( $term_links ) ) {
+			foreach ( $term_links as $key => $url ) {
+				$invalidation_batch->put_invalidation_path( $url );
+			}
 		}
 		$archive_links = $this->post->get_the_post_type_archive_links();
-		foreach ( $archive_links as $key => $url ) {
-			$invalidation_batch->put_invalidation_path( $url );
+		if ( ! is_wp_error( $archive_links ) ) {
+			foreach ( $archive_links as $key => $url ) {
+				$invalidation_batch->put_invalidation_path( $url );
+			}
 		}
 		$invalidation_batch->apply_invalidation_item_filter( $post );
 		return $invalidation_batch;

--- a/classes/Invalidation_Service.php
+++ b/classes/Invalidation_Service.php
@@ -170,10 +170,14 @@ class Invalidation_Service {
 			return;
 		}
 
-		$invalidation_target = $_POST['invalidation_target'];
+		if ( ! current_user_can( 'cloudfront_clear_cache' ) ) {
+			return;
+		}
+
+		$invalidation_target = sanitize_text_field( wp_unslash( $_POST['invalidation_target'] ?? '' ) );
 
 		try {
-			if ( ! isset( $invalidation_target ) ) {
+			if ( '' === $invalidation_target ) {
 				throw new \Error( 'invalidation_target is required' );
 			}
 			if ( 'all' === $invalidation_target ) {
@@ -205,7 +209,7 @@ class Invalidation_Service {
 	 */
 	public function register_cron_event( $query ) {
 		$this->debug_logger->log_cron_registration_start();
-		if ( ! isset( $query['Paths'] ) || ! isset( $query['Paths']['Items'] ) || $query['Paths']['Items'][0] === '/*' ) {
+		if ( ! isset( $query['Paths'] ) || ! isset( $query['Paths']['Items'] ) || 0 === count( $query['Paths']['Items'] ) ) {
 			$this->debug_logger->log_cron_registration_skip( '===== C3 CRON Job registration [SKIP | NO ITEM] ===' );
 			return false;
 		}
@@ -442,8 +446,8 @@ class Invalidation_Service {
 			wp_die( 'Insufficient permissions' );
 		}
 
-		$invalidation_id = sanitize_text_field( $_POST['invalidation_id'] ?? '' );
-		if ( empty( $invalidation_id ) ) {
+		$invalidation_id = sanitize_text_field( wp_unslash( $_POST['invalidation_id'] ?? '' ) );
+		if ( empty( $invalidation_id ) || ! preg_match( '/^[A-Z0-9]+$/i', $invalidation_id ) ) {
 			wp_send_json_error( 'Invalid invalidation ID' );
 		}
 

--- a/classes/Views/Settings.php
+++ b/classes/Views/Settings.php
@@ -100,20 +100,36 @@ class Settings {
 	/**
 	 * Filter the saving option's request
 	 *
+	 * The credential fields are rendered empty on the settings page, so an
+	 * empty submitted value means "keep the stored credential" rather than
+	 * "delete it". Use WP-CLI (`wp c3 update`) to clear a stored credential.
+	 *
 	 * @param mixed $args form parameter.
 	 */
 	function filter_and_escape( $args ) {
-		$allow_keys = array(
+		$allow_keys      = array(
 			Constants::DISTRIBUTION_ID,
 			Constants::ACCESS_KEY,
 			Constants::SECRET_KEY,
 		);
-		$items      = array();
+		$credential_keys = array(
+			Constants::ACCESS_KEY,
+			Constants::SECRET_KEY,
+		);
+		$existing        = get_option( Constants::OPTION_NAME, array() );
+		$items           = array();
 		foreach ( $allow_keys as $key ) {
 			if ( ! array_key_exists( $key, $args ) ) {
 				continue;
 			}
-			$items[ $key ] = esc_attr( $args[ $key ] );
+			$value = sanitize_text_field( (string) $args[ $key ] );
+			if ( '' === $value && in_array( $key, $credential_keys, true ) ) {
+				if ( is_array( $existing ) && isset( $existing[ $key ] ) && '' !== $existing[ $key ] ) {
+					$items[ $key ] = $existing[ $key ];
+				}
+				continue;
+			}
+			$items[ $key ] = $value;
 		}
 		return $items;
 	}

--- a/classes/WP/Environment.php
+++ b/classes/WP/Environment.php
@@ -28,6 +28,14 @@ class Environment {
 	 * @since 6.0.0
 	 */
 	public function is_amimoto_managed() {
+		/**
+		 * The X-Amimoto-Managed header is client-controlled, so it must not be
+		 * trusted on its own. Require a server-side marker (IS_AMIMOTO or
+		 * AMIMOTO_CDN_ID defined in the code) before honoring it.
+		 */
+		if ( ! $this->is_amimoto() && ! $this->has_managed_cdn() ) {
+			return false;
+		}
 		if ( isset( $_SERVER['HTTP_X_AMIMOTO_MANAGED'] ) && $_SERVER['HTTP_X_AMIMOTO_MANAGED'] ) {
 			return true;
 		}

--- a/classes/WP/Fixtures.php
+++ b/classes/WP/Fixtures.php
@@ -114,6 +114,7 @@ class Fixtures {
 				'expires'  => $expires,
 				'samesite' => 'None',
 				'secure'   => true,
+				'httponly' => true,
 				'path'     => $cookie_path,
 			);
 			setcookie( $key, $value, $args );

--- a/classes/WP/Options.php
+++ b/classes/WP/Options.php
@@ -33,7 +33,8 @@ class Options {
 	 * @param mixed $params Plugin options.
 	 */
 	public function update_options( $params ) {
-		return update_option( Constants::OPTION_NAME, $params );
+		// Contains AWS credentials: do not autoload it on every request.
+		return update_option( Constants::OPTION_NAME, $params, false );
 	}
 
 	/**

--- a/classes/WP/Post.php
+++ b/classes/WP/Post.php
@@ -143,13 +143,13 @@ class Post {
 	}
 
 	/**
-	 * Load the post's term links
+	 * Load the post's post type archive links
 	 *
-	 * @throws \WP_Error If no post provided, should throw it.
+	 * @return \WP_Error|string[] Return WP_Error if no post provided.
 	 */
 	public function get_the_post_type_archive_links() {
 		if ( ! $this->post ) {
-			throw new \WP_Error( 'Post is required' );
+			return new \WP_Error( 'Post is required' );
 		}
 		$post = $this->post;
 		$url  = $this->parse_url( get_post_type_archive_link( $post->post_type ) );

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: amimotoami,hideokamoto,megumithemes,wokamoto,miyauchi,hnle,bartoszgadomski,jepser,johnbillion,pacifika
 Donate link: http://wp-kyoto.net/
 Tags: AWS,CDN,CloudFront
-Requires at least: 4.9.0
+Requires at least: 5.5
 Tested up to: 6.9.1
 Stable tag: 7.3.2
 License: GPLv3 or later

--- a/templates/Invalidation_Logs.php
+++ b/templates/Invalidation_Logs.php
@@ -172,6 +172,10 @@ if ( is_wp_error( $histories ) ) {
 
 <script>
 jQuery(document).ready(function($) {
+	function c3EscapeHtml(value) {
+		return $('<div>').text(String(value)).html();
+	}
+
 	$('.c3-view-details').on('click', function() {
 		var invalidationId = $(this).data('invalidation-id');
 		var modal = $('#c3-invalidation-details-modal');
@@ -189,27 +193,27 @@ jQuery(document).ready(function($) {
 				var data = response.data;
 				var html = '<div class="c3-detail-row">' +
 					'<div class="c3-detail-label"><?php _e( 'Invalidation ID', $text_domain ); ?>:</div>' +
-					'<div class="c3-detail-value">' + data.Id + '</div>' +
+					'<div class="c3-detail-value">' + c3EscapeHtml(data.Id) + '</div>' +
 					'</div>' +
 					'<div class="c3-detail-row">' +
 					'<div class="c3-detail-label"><?php _e( 'Status', $text_domain ); ?>:</div>' +
-					'<div class="c3-detail-value">' + data.Status + '</div>' +
+					'<div class="c3-detail-value">' + c3EscapeHtml(data.Status) + '</div>' +
 					'</div>' +
 					'<div class="c3-detail-row">' +
 					'<div class="c3-detail-label"><?php _e( 'Create Time', $text_domain ); ?>:</div>' +
-					'<div class="c3-detail-value">' + data.CreateTime + '</div>' +
+					'<div class="c3-detail-value">' + c3EscapeHtml(data.CreateTime) + '</div>' +
 					'</div>';
-				
+
 				if (data.InvalidationBatch && data.InvalidationBatch.CallerReference) {
 					html += '<div class="c3-detail-row">' +
 						'<div class="c3-detail-label"><?php _e( 'Caller Reference', $text_domain ); ?>:</div>' +
-						'<div class="c3-detail-value">' + data.InvalidationBatch.CallerReference + '</div>' +
+						'<div class="c3-detail-value">' + c3EscapeHtml(data.InvalidationBatch.CallerReference) + '</div>' +
 						'</div>';
 				}
-				
+
 				if (data.InvalidationBatch && data.InvalidationBatch.Paths && data.InvalidationBatch.Paths.Items) {
 					html += '<div class="c3-detail-row">' +
-						'<div class="c3-detail-label"><?php _e( 'Invalidated Paths', $text_domain ); ?> (' + data.InvalidationBatch.Paths.Quantity + '):</div>' +
+						'<div class="c3-detail-label"><?php _e( 'Invalidated Paths', $text_domain ); ?> (' + c3EscapeHtml(data.InvalidationBatch.Paths.Quantity) + '):</div>' +
 						'<div class="c3-paths-list">';
 					
 					var items = Array.isArray(data.InvalidationBatch.Paths.Items) 
@@ -218,10 +222,10 @@ jQuery(document).ready(function($) {
 					
 					items.forEach(function(pathItem) {
 						if (typeof pathItem === 'string') {
-							html += '<div>' + pathItem + '</div>';
+							html += '<div>' + c3EscapeHtml(pathItem) + '</div>';
 						} else if (pathItem && typeof pathItem === 'object' && pathItem.Path && Array.isArray(pathItem.Path)) {
 							pathItem.Path.forEach(function(actualPath) {
-								html += '<div>' + actualPath + '</div>';
+								html += '<div>' + c3EscapeHtml(actualPath) + '</div>';
 							});
 						} else if (pathItem && typeof pathItem === 'object') {
 							var pathString = '';
@@ -232,7 +236,7 @@ jQuery(document).ready(function($) {
 								var value = pathItem[key];
 								if (Array.isArray(value)) {
 									value.forEach(function(actualPath) {
-										html += '<div>' + actualPath + '</div>';
+										html += '<div>' + c3EscapeHtml(actualPath) + '</div>';
 									});
 									return;
 								} else {
@@ -241,9 +245,9 @@ jQuery(document).ready(function($) {
 							} else {
 								pathString = String(pathItem);
 							}
-							html += '<div>' + pathString + '</div>';
+							html += '<div>' + c3EscapeHtml(pathString) + '</div>';
 						} else {
-							html += '<div>' + String(pathItem) + '</div>';
+							html += '<div>' + c3EscapeHtml(pathItem) + '</div>';
 						}
 					});
 					
@@ -252,7 +256,7 @@ jQuery(document).ready(function($) {
 				
 				content.html(html);
 			} else {
-				content.html('<div class="c3-error">' + response.data + '</div>');
+				content.html('<div class="c3-error">' + c3EscapeHtml(response.data) + '</div>');
 			}
 		}).fail(function() {
 			content.html('<div class="c3-error"><?php _e( 'Failed to load invalidation details.', $text_domain ); ?></div>');

--- a/templates/Plugin_Options.php
+++ b/templates/Plugin_Options.php
@@ -66,7 +66,9 @@ $has_ec2_instance_role = apply_filters( 'c3_has_ec2_instance_role', false );
 						class='regular-text code'
 						type="password"
 						name="<?php echo isset( $env_access_key ) ? Constants::OPTION_NAME . '[dummy1]' : Constants::OPTION_NAME . '[' . Constants::ACCESS_KEY . ']'; ?>"
-						value="<?php echo esc_attr( isset( $env_access_key ) ? $env_access_key : $access_key ); ?>"
+						value=""
+						autocomplete="off"
+						placeholder="<?php echo isset( $access_key ) && '' !== $access_key ? esc_attr__( 'Saved. Leave blank to keep the current value.', $text_domain ) : ''; ?>"
 						<?php echo isset( $env_access_key ) ? 'disabled' : ''; ?>
 					/>
 					<?php
@@ -86,7 +88,9 @@ $has_ec2_instance_role = apply_filters( 'c3_has_ec2_instance_role', false );
 						class='regular-text code'
 						type="password"
 						name="<?php echo isset( $env_secret_key ) ? Constants::OPTION_NAME . '[dummy2]' : Constants::OPTION_NAME . '[' . Constants::SECRET_KEY . ']'; ?>"
-						value="<?php echo esc_attr( isset( $env_secret_key ) ? $env_secret_key : $secret_key ); ?>"
+						value=""
+						autocomplete="off"
+						placeholder="<?php echo isset( $secret_key ) && '' !== $secret_key ? esc_attr__( 'Saved. Leave blank to keep the current value.', $text_domain ) : ''; ?>"
 						<?php echo isset( $env_secret_key ) ? 'disabled' : ''; ?>
 					/>
 					<?php
@@ -100,7 +104,7 @@ $has_ec2_instance_role = apply_filters( 'c3_has_ec2_instance_role', false );
 		<?php } ?>
 	</tbody></table>
 	<?php
-	if ( ! isset( $env_distribution_id ) || ! isset( $env_secret_key ) || ! isset( $env_secret_key ) ) {
+	if ( ! isset( $env_distribution_id ) || ! isset( $env_access_key ) || ! isset( $env_secret_key ) ) {
 		settings_fields( Constants::MENU_ID );
 		submit_button();
 	}

--- a/tests/Invalidation_Service_Test.php
+++ b/tests/Invalidation_Service_Test.php
@@ -142,6 +142,11 @@ class Invalidation_Service_Test extends \WP_UnitTestCase {
                 ),
             ],
             [
+                /**
+                 * A '/*' query can now reach here when a batch collapses to '/*'
+                 * (over the path limit), so it must be scheduled instead of
+                 * being silently dropped.
+                 */
                 array(
                     'Paths' => array(
                         'Items' => array(
@@ -150,7 +155,8 @@ class Invalidation_Service_Test extends \WP_UnitTestCase {
                     )
                 ),
                 array(
-                    'should_registered' => false
+                    'should_registered' => true,
+                    'timestamp' => time() + MINUTE_IN_SECONDS * 1
                 ),
             ],
             [


### PR DESCRIPTION
コミット `2e8a9f0`(fix: harden security and safety across the plugin)の内容を解説します。16 ファイル、+118/−44 行の変更で、新機能はなく、すべて監査で確認した問題の修正です。

## セキュリティ修正

**1. DOM XSS の修正 — [templates/Invalidation_Logs.php](../c3-cloudfront-clear-cache/templates/Invalidation_Logs.php)**(最重要)
設定ページの「View Details」モーダルは、AJAX レスポンスの値(Invalidation ID、ステータス、日時、CallerReference、無効化パス一覧、エラーメッセージ)を文字列連結で HTML に組み立て、jQuery の `.html()` でそのまま挿入していました。値に HTML が含まれると管理者のブラウザ上でスクリプトとして実行されます。`c3EscapeHtml()` ヘルパー(DOM のテキストノードを経由してエスケープ)を追加し、11 か所の挿入ポイントすべてに適用しました。

**2. XXE 対策 — [CloudFront_HTTP_Client.php:296](../c3-cloudfront-clear-cache/classes/AWS/CloudFront_HTTP_Client.php:296)**
XML パースで `LIBXML_NOENT` を渡していました。このフラグは名前に反してエンティティ展開を「有効化」するもので、XXE 攻撃(ローカルファイル読み出し、billion-laughs 展開)の主要因です。フラグを削除し、後から誤って戻されないようコメントで理由を明記しました。

**3. 偽装可能なヘッダーによる環境判定 — [Environment.php:30](../c3-cloudfront-clear-cache/classes/WP/Environment.php:30)**
`is_amimoto_managed()` は、誰でも送信できる `X-Amimoto-Managed` HTTP ヘッダーだけで true を返していました。偽装ヘッダー付きリクエストでは、保存済みクレデンシャルが無視され、設定 UI も非表示になります。修正後は、サーバー側の定数(`IS_AMIMOTO` または `AMIMOTO_CDN_ID`)が定義されている場合に限りヘッダーを信頼します。AMIMOTO マネージド環境で必ずこれらの定数が定義されているか、チームでの確認をお願いしたい点です(PR にも明記済み)。

**4. 手動キャッシュ削除の強化 — [Invalidation_Service.php:173](../c3-cloudfront-clear-cache/classes/Invalidation_Service.php:173)**
「Flush All Cache」「Flush by post IDs」のハンドラーは毎回の `admin_init` で動作し、以前は nonce 検証のみでした。`cloudfront_clear_cache` 権限チェックを追加し、`invalidation_target` は `$_POST` の生の値ではなく `wp_unslash()` + `sanitize_text_field()` を通すようにしました。

**5. クレデンシャルをフォームに出力しない — [templates/Plugin_Options.php](../c3-cloudfront-clear-cache/templates/Plugin_Options.php) + [Views/Settings.php](../c3-cloudfront-clear-cache/classes/Views/Settings.php)**
保存済みの AWS アクセスキー・シークレットキーが password 入力の `value` として描画され、ページソースに露出していました。修正後はフィールドを常に空で描画し、プレースホルダー(「Saved. Leave blank to keep the current value.」)と `autocomplete="off"` を追加。あわせて保存時の `filter_and_escape()` を「クレデンシャル欄が空なら保存済みの値を維持する」動作に変更しました。付随する 2 点に注意してください。
- **動作変更**: UI からクレデンシャルを空にして削除することはできなくなりました。削除は `wp c3 update` で行います。
- **潜在バグ修正**: サニタイズを `esc_attr()` から `sanitize_text_field()` に変更。`esc_attr()` は `&` などを HTML エンコードするため、これらを含むシークレットが保存時に壊れていました。

**6. AJAX 入力の厳格化 — [Invalidation_Service.php:449](../c3-cloudfront-clear-cache/classes/Invalidation_Service.php:449)**
`invalidation_id` は署名付き CloudFront API の URL に埋め込まれるため、サニタイズに加えて `^[A-Z0-9]+$` の形式チェックを追加しました(`../` によるパストラバーサルを遮断)。

**7. オプションの autoload 無効化 — [Options.php:37](../c3-cloudfront-clear-cache/classes/WP/Options.php:37)**
シークレットキーを含む `c3_settings` を `autoload = false` で保存し、全リクエストで毎回メモリに読み込まれないようにしました。

**8. IMDSv1 のオプトアウト — [EC2_Metadata_Service.php](../c3-cloudfront-clear-cache/classes/AWS/EC2_Metadata_Service.php)**
トークンなしの IMDSv1 フォールバック(SSRF に対する多層防御を弱める要素)を、新設の `c3_use_imdsv1_fallback` フィルターで制御できるようにしました。デフォルトは `true` なので既存動作は変わらず、`add_filter( 'c3_use_imdsv1_fallback', '__return_false' )` で無効化できます。

## セイフティ・正確性の修正

**9. 潜在的な致命的エラー — [Post.php:150](../c3-cloudfront-clear-cache/classes/WP/Post.php:150)**
`get_the_post_type_archive_links()` が `throw new \WP_Error(...)` していました。`WP_Error` は `Throwable` ではないため、この行に到達するとエラーハンドリングではなく致命的な `TypeError` になります。`return` に変更し、呼び出し側の [Invalidation_Batch_Service.php:97](../c3-cloudfront-clear-cache/classes/AWS/Invalidation_Batch_Service.php:97) にも `is_wp_error()` ガードを追加しました。

**10. 休眠していたパス数上限の有効化 — [Invalidation_Batch.php:84](../c3-cloudfront-clear-cache/classes/AWS/Invalidation_Batch.php:84)**
「パスが 10 件を超えたら `/*` にまとめる」という `get_invalidation_path_items()` が実装済みなのにどこからも呼ばれておらず、大量パスの強制フラッシュが CloudFront のワイルドカード上限を超えて失敗し得ました。`get_invalidation_batch()` から呼ぶように接続。これに伴い [Invalidation_Service.php:212](../c3-cloudfront-clear-cache/classes/Invalidation_Service.php:212) の `register_cron_event()` は、`/*` クエリをスキップ(以前は「Success」と表示しつつ実際には何もしない = 静かに破棄)せず、cron に登録するよう変更しました。旧動作を前提にしていたテストケース 1 件を更新し、理由をインラインコメントで説明しています([tests/Invalidation_Service_Test.php](../c3-cloudfront-clear-cache/tests/Invalidation_Service_Test.php))。

**11. 本番ログのノイズ — [CloudFront_Service.php](../c3-cloudfront-clear-cache/classes/AWS/CloudFront_Service.php)**
`list_invalidations()` が設定ページを開くたびに無条件で `error_log()` を 4 回実行していました(API レスポンス全体の `print_r` ダンプを含む)。周辺のデバッグログと同じく `WP_DEBUG` 有効時のみに変更。実際の失敗を記録するログはそのまま残しています。

**12. WordPress 最低バージョン — [readme.txt](../c3-cloudfront-clear-cache/readme.txt) + プラグインヘッダー**
コードは WP 5.5 以降にしか存在しない `esc_xml()` を使っているのに、readme は 4.9.0 対応を謳っていました(4.9〜5.4 では無効化リクエスト生成時に致命的エラー)。「Requires at least: 5.5」を readme とプラグインヘッダー(従来は未記載)の両方に設定しました。

**13. Cookie の強化 — [Fixtures.php:117](../c3-cloudfront-clear-cache/classes/WP/Fixtures.php:117)**
`set_cookie()` の PHP 7.3 以降の分岐だけ `httponly` が抜けていました(旧分岐では設定済み)。`'httponly' => true` を追加して揃えました。

**14. テンプレートの条件式の誤り — [templates/Plugin_Options.php:107](../c3-cloudfront-clear-cache/templates/Plugin_Options.php:107)**
送信ボタンの表示判定が `! isset( $env_secret_key )` を 2 回チェックし、`$env_access_key` を見ていませんでした。3 つの環境変数すべてを確認するよう修正しました。

レビューで特に注意してほしいのは、意図的な動作変更を含む 3 点です: **#3**(AMIMOTO マネージドが必ず定数を定義している前提)、**#5**(UI からクレデンシャルを空にできない)、**#10**(大量バッチが失敗ではなく `/*` の全体フラッシュに変わる)。それ以外は純粋な強化です。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for XML handling and modal content display.
  * Fixed invalidation handling so bad data is ignored more safely.
  * Preserved saved access keys when settings fields are left blank.
  * Tightened environment and credentials detection for more reliable behavior.

* **New Features**
  * Added clearer support for keeping existing credentials in the settings screen.
  * Updated the minimum supported WordPress version to 5.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->